### PR TITLE
fix: add context to callback handler

### DIFF
--- a/oauth/handlers.go
+++ b/oauth/handlers.go
@@ -67,22 +67,22 @@ func NewLoginHandler(path string, cfg Config) (*rocco.Handler[rocco.NoBody, rocc
 //
 // The respond function determines what is returned to the client. Common patterns:
 //
-//   - Redirect to dashboard: func(t *TokenResponse) (rocco.Redirect, error) { return rocco.Redirect{URL: "/dashboard"}, nil }
-//   - Return JSON: func(t *TokenResponse) (MyResponse, error) { return MyResponse{Token: t.AccessToken}, nil }
+//   - Redirect to dashboard: func(ctx context.Context, t *TokenResponse) (rocco.Redirect, error) { return rocco.Redirect{URL: "/dashboard"}, nil }
+//   - Return JSON: func(ctx context.Context, t *TokenResponse) (MyResponse, error) { return MyResponse{Token: t.AccessToken}, nil }
 //
 // Returns an error if the config is invalid (missing required fields or callbacks).
 //
 // Example:
 //
 //	callback, err := oauth.NewCallbackHandler("/auth/github/callback", cfg,
-//	    func(tokens *oauth.TokenResponse) (rocco.Redirect, error) {
+//	    func(ctx context.Context, tokens *oauth.TokenResponse) (rocco.Redirect, error) {
 //	        return rocco.Redirect{URL: "/dashboard"}, nil
 //	    })
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
 //	engine.WithHandlers(callback)
-func NewCallbackHandler[Out any](path string, cfg Config, respond func(*TokenResponse) (Out, error)) (*rocco.Handler[rocco.NoBody, Out], error) {
+func NewCallbackHandler[Out any](path string, cfg Config, respond func(context.Context, *TokenResponse) (Out, error)) (*rocco.Handler[rocco.NoBody, Out], error) {
 	cfg.defaults()
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("oauth: invalid config: %w", err)
@@ -134,7 +134,7 @@ func NewCallbackHandler[Out any](path string, cfg Config, respond func(*TokenRes
 		}
 
 		// Return response via user-provided function
-		return respond(tokens)
+		return respond(req.Context, tokens)
 	}).
 		WithName(cfg.Name + "-callback").
 		WithSummary("Handle " + cfg.Name + " OAuth callback").

--- a/oauth/handlers_test.go
+++ b/oauth/handlers_test.go
@@ -100,7 +100,7 @@ func TestNewCallbackHandler_ProviderError(t *testing.T) {
 		OnSuccess:   func(ctx context.Context, tokens *TokenResponse) error { return nil },
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{URL: "/dashboard"}, nil
 	})
 	if err != nil {
@@ -165,7 +165,7 @@ func TestNewCallbackHandler_TokenExchangeFailure(t *testing.T) {
 		OnSuccess:   func(ctx context.Context, tokens *TokenResponse) error { return nil },
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{URL: "/dashboard"}, nil
 	})
 	if err != nil {
@@ -204,7 +204,7 @@ func TestNewCallbackHandler_InvalidJSONResponse(t *testing.T) {
 		OnSuccess:   func(ctx context.Context, tokens *TokenResponse) error { return nil },
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{URL: "/dashboard"}, nil
 	})
 	if err != nil {
@@ -247,7 +247,7 @@ func TestNewCallbackHandler_OnSuccessFailure(t *testing.T) {
 		},
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{URL: "/dashboard"}, nil
 	})
 	if err != nil {
@@ -281,7 +281,7 @@ func TestNewCallbackHandler_StateVerificationError(t *testing.T) {
 		OnSuccess: func(ctx context.Context, tokens *TokenResponse) error { return nil },
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{URL: "/dashboard"}, nil
 	})
 	if err != nil {
@@ -322,7 +322,7 @@ func TestNewCallbackHandler_RespondError(t *testing.T) {
 		OnSuccess:   func(ctx context.Context, tokens *TokenResponse) error { return nil },
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{}, rocco.ErrInternalServer.WithMessage("respond failed")
 	})
 	if err != nil {
@@ -458,7 +458,7 @@ func TestNewCallbackHandler_ProviderErrorWithoutDescription(t *testing.T) {
 		OnSuccess:   func(ctx context.Context, tokens *TokenResponse) error { return nil },
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{URL: "/dashboard"}, nil
 	})
 	if err != nil {

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -20,7 +20,7 @@
 //
 //	login := oauth.NewLoginHandler("/auth/github", cfg)
 //	callback := oauth.NewCallbackHandler("/auth/github/callback", cfg,
-//	    func(tokens *oauth.TokenResponse) (rocco.Redirect, error) {
+//	    func(ctx context.Context, tokens *oauth.TokenResponse) (rocco.Redirect, error) {
 //	        return rocco.Redirect{URL: "/dashboard"}, nil
 //	    })
 //

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -206,7 +206,7 @@ func TestNewCallbackHandler_Success(t *testing.T) {
 		Success bool `json:"success"`
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (callbackResponse, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (callbackResponse, error) {
 		return callbackResponse{Success: true}, nil
 	})
 	if err != nil {
@@ -261,7 +261,7 @@ func TestNewCallbackHandler_InvalidState(t *testing.T) {
 		},
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{URL: "/dashboard"}, nil
 	})
 	if err != nil {
@@ -304,7 +304,7 @@ func TestNewCallbackHandler_MissingCode(t *testing.T) {
 		},
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{URL: "/dashboard"}, nil
 	})
 	if err != nil {
@@ -349,7 +349,7 @@ func TestNewCallbackHandler_WithRedirect(t *testing.T) {
 		},
 	}
 
-	handler, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	handler, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{URL: "/dashboard"}, nil
 	})
 	if err != nil {
@@ -400,7 +400,7 @@ func TestNewCallbackHandler_ValidationError(t *testing.T) {
 		// Missing TokenURL, ClientID, ClientSecret, etc.
 	}
 
-	_, err := NewCallbackHandler("/auth/callback", cfg, func(tokens *TokenResponse) (rocco.Redirect, error) {
+	_, err := NewCallbackHandler("/auth/callback", cfg, func(ctx context.Context, tokens *TokenResponse) (rocco.Redirect, error) {
 		return rocco.Redirect{URL: "/dashboard"}, nil
 	})
 	if err == nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * OAuth callback handler now requires callbacks to accept a context parameter as the first argument.

* **Tests**
  * Updated callback handler test cases to reflect new signature requirements.

* **Documentation**
  * Updated examples showing context-aware callback function signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->