### PR TITLE
fix: use ctx on hooks

### DIFF
--- a/docs/3.guides/1.handlers.md
+++ b/docs/3.guides/1.handlers.md
@@ -260,58 +260,57 @@ Middleware executes in order: first added runs first.
 
 ## Hooks
 
-Hooks provide typed data transformation at handler entry and exit. Unlike middleware, which operates on `http.Request`/`http.ResponseWriter`, hooks work directly with the typed `In` and `Out` structs.
+Hooks provide typed data transformation at handler entry and exit. Unlike middleware, which operates on `http.Request`/`http.ResponseWriter`, hooks work directly with the typed `In` and `Out` structs. Input types implement `Entryable` and output types implement `Sendable` — following the same opt-in interface pattern as `Validatable`.
 
-### OnEntry
+### Entryable
 
-Transforms input data after body parsing and validation, before the handler function:
+Implement the `Entryable` interface on an input type to transform it after body parsing and validation, before the handler function:
 
 ```go
-handler := rocco.POST[CreateUserInput, User]("/users", createUser).
-    OnEntry(func(in CreateUserInput) (CreateUserInput, error) {
-        in.Email = strings.ToLower(in.Email)
-        return in, nil
-    })
+type CreateUserInput struct {
+    Email string `json:"email"`
+}
+
+func (in *CreateUserInput) OnEntry(ctx context.Context) error {
+    in.Email = strings.ToLower(in.Email)
+    return nil
+}
 ```
 
-### OnSend
-
-Transforms output data after the handler function, before marshalling:
+The handler detects the interface automatically:
 
 ```go
-handler := rocco.GET[rocco.NoBody, UserList]("/users", listUsers).
-    OnSend(func(out UserList) (UserList, error) {
-        for i := range out.Users {
-            out.Users[i].Email = "" // Strip emails from response
-        }
-        return out, nil
-    })
+handler := rocco.POST[CreateUserInput, User]("/users", createUser)
 ```
 
-### Multiple Hooks
+### Sendable
 
-Hooks run in registration order. Multiple hooks compose naturally:
+Implement the `Sendable` interface on an output type to transform it after the handler function, before marshalling:
 
 ```go
-handler := rocco.POST[OrderInput, Order]("/orders", createOrder).
-    OnEntry(normalise).
-    OnEntry(enrichDefaults).
-    OnSend(redactInternals).
-    OnSend(addMetadata)
+type UserList struct {
+    Users []User `json:"users"`
+}
+
+func (out *UserList) OnSend(ctx context.Context) error {
+    for i := range out.Users {
+        out.Users[i].Email = "" // Strip emails from response
+    }
+    return nil
+}
 ```
 
 ### Error Handling
 
-Returning an error from any hook short-circuits processing and returns 500 Internal Server Error:
+Returning an error from a hook short-circuits processing and returns 500 Internal Server Error:
 
 ```go
-handler := rocco.POST[Input, Output]("/path", handle).
-    OnEntry(func(in Input) (Input, error) {
-        if in.TenantID == "" {
-            return in, errors.New("tenant ID required")
-        }
-        return in, nil
-    })
+func (in *OrderInput) OnEntry(ctx context.Context) error {
+    if in.TenantID == "" {
+        return errors.New("tenant ID required")
+    }
+    return nil
+}
 ```
 
 ### Hooks vs Middleware
@@ -321,6 +320,7 @@ handler := rocco.POST[Input, Output]("/path", handle).
 | Operates on | Typed `In`/`Out` structs | `http.Request`/`http.ResponseWriter` |
 | Can modify | Input data, output data | Headers, context, request flow |
 | Runs | Inside `Process()`, after parsing | Outside `Process()`, before parsing |
+| Access to | `context.Context` | `http.Request`/`http.ResponseWriter` |
 | Use for | Data transformation, normalisation | Logging, CORS, rate limiting |
 
 ## Handler Patterns

--- a/handler.go
+++ b/handler.go
@@ -54,8 +54,8 @@ type Handler[In, Out any] struct {
 	middleware []func(http.Handler) http.Handler
 
 	// Hooks.
-	onEntry []func(In) (In, error)
-	onSend  []func(Out) (Out, error)
+	inputEntryable bool // True if In implements Entryable.
+	outputSendable bool // True if Out implements Sendable.
 }
 
 // Process implements Endpoint.
@@ -138,16 +138,17 @@ func (h *Handler[In, Out]) Process(ctx context.Context, r *http.Request, w http.
 		}
 	}
 
-	// Run entry hooks.
-	for _, hook := range h.onEntry {
-		input, err = hook(input)
-		if err != nil {
-			capitan.Error(ctx, HandlerError,
-				HandlerNameKey.Field(h.spec.Name),
-				ErrorKey.Field(err.Error()),
-			)
-			writeError(ctx, w, ErrInternalServer.WithCause(err), h.spec.ContentType, h.spec.Name)
-			return http.StatusInternalServerError, err
+	// Run entry hook.
+	if h.inputEntryable {
+		if e, ok := any(&input).(Entryable); ok {
+			if err = e.OnEntry(ctx); err != nil {
+				capitan.Error(ctx, HandlerError,
+					HandlerNameKey.Field(h.spec.Name),
+					ErrorKey.Field(err.Error()),
+				)
+				writeError(ctx, w, ErrInternalServer.WithCause(err), h.spec.ContentType, h.spec.Name)
+				return http.StatusInternalServerError, err
+			}
 		}
 	}
 
@@ -204,16 +205,17 @@ func (h *Handler[In, Out]) Process(ctx context.Context, r *http.Request, w http.
 		return http.StatusInternalServerError, err
 	}
 
-	// Run send hooks.
-	for _, hook := range h.onSend {
-		output, err = hook(output)
-		if err != nil {
-			capitan.Error(ctx, HandlerError,
-				HandlerNameKey.Field(h.spec.Name),
-				ErrorKey.Field(err.Error()),
-			)
-			writeError(ctx, w, ErrInternalServer.WithCause(err), h.spec.ContentType, h.spec.Name)
-			return http.StatusInternalServerError, err
+	// Run send hook.
+	if h.outputSendable {
+		if e, ok := any(&output).(Sendable); ok {
+			if err = e.OnSend(ctx); err != nil {
+				capitan.Error(ctx, HandlerError,
+					HandlerNameKey.Field(h.spec.Name),
+					ErrorKey.Field(err.Error()),
+				)
+				writeError(ctx, w, ErrInternalServer.WithCause(err), h.spec.ContentType, h.spec.Name)
+				return http.StatusInternalServerError, err
+			}
 		}
 	}
 
@@ -330,6 +332,8 @@ func NewHandler[In, Out any](name string, method, path string, fn func(*Request[
 	var zeroOut Out
 	_, inputValidatable := any(zeroIn).(Validatable)
 	_, outputValidatable := any(zeroOut).(Validatable)
+	_, inputEntryable := any(&zeroIn).(Entryable)
+	_, outputSendable := any(&zeroOut).(Sendable)
 
 	return &Handler[In, Out]{
 		fn: fn,
@@ -357,9 +361,9 @@ func NewHandler[In, Out any](name string, method, path string, fn func(*Request[
 		OutputMeta:        outputMeta,
 		inputValidatable:  inputValidatable,
 		outputValidatable: outputValidatable,
+		inputEntryable:    inputEntryable,
+		outputSendable:    outputSendable,
 		middleware:        make([]func(http.Handler) http.Handler, 0),
-		onEntry:           make([]func(In) (In, error), 0),
-		onSend:            make([]func(Out) (Out, error), 0),
 	}
 }
 
@@ -518,20 +522,6 @@ func (h *Handler[In, Out]) applyDefaultCodec(codec Codec) {
 		h.codec = codec
 		h.spec.ContentType = codec.ContentType()
 	}
-}
-
-// OnEntry adds a hook that transforms the input before the handler executes.
-// Hooks run in order after body parsing and validation, before the handler function.
-func (h *Handler[In, Out]) OnEntry(fn func(In) (In, error)) *Handler[In, Out] {
-	h.onEntry = append(h.onEntry, fn)
-	return h
-}
-
-// OnSend adds a hook that transforms the output after the handler executes.
-// Hooks run in order after the handler function, before output validation and marshaling.
-func (h *Handler[In, Out]) OnSend(fn func(Out) (Out, error)) *Handler[In, Out] {
-	h.onSend = append(h.onSend, fn)
-	return h
 }
 
 // WithMiddleware adds middleware to this handler and returns the handler for chaining.

--- a/handler_test.go
+++ b/handler_test.go
@@ -1202,24 +1202,77 @@ func TestWithName(t *testing.T) {
 	}
 }
 
+// entryCtxKey is a context key for testing OnEntry receives context.
+type entryCtxKey struct{}
+
+// entryCtxInput implements Entryable and reads from context.
+type entryCtxInput struct {
+	Name string `json:"name"`
+}
+
+func (e *entryCtxInput) OnEntry(ctx context.Context) error {
+	if v, ok := ctx.Value(entryCtxKey{}).(string); ok {
+		e.Name = v + "-" + e.Name
+	}
+	return nil
+}
+
+// entryInput implements Entryable for testing.
+type entryInput struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func (e *entryInput) OnEntry(_ context.Context) error {
+	e.Name = "modified-" + e.Name
+	e.Count = e.Count * 10
+	return nil
+}
+
+// entryInputError implements Entryable and always returns an error.
+type entryInputError struct {
+	Name string `json:"name"`
+}
+
+func (e *entryInputError) OnEntry(_ context.Context) error {
+	return errors.New("entry hook failed")
+}
+
+// sendOutput implements Sendable for testing.
+type sendOutput struct {
+	Message string `json:"message"`
+	Result  int    `json:"result"`
+}
+
+func (s *sendOutput) OnSend(_ context.Context) error {
+	s.Message = s.Message + "-transformed"
+	s.Result = s.Result * 2
+	return nil
+}
+
+// sendOutputError implements Sendable and always returns an error.
+type sendOutputError struct {
+	Message string `json:"message"`
+}
+
+func (s *sendOutputError) OnSend(_ context.Context) error {
+	return errors.New("send hook failed")
+}
+
 func TestHandler_OnEntry(t *testing.T) {
-	handler := NewHandler[testInput, testOutput](
+	handler := NewHandler[entryInput, testOutput](
 		"test",
 		"POST",
 		"/test",
-		func(req *Request[testInput]) (testOutput, error) {
+		func(req *Request[entryInput]) (testOutput, error) {
 			return testOutput{
 				Message: req.Body.Name,
 				Result:  req.Body.Count,
 			}, nil
 		},
-	).OnEntry(func(in testInput) (testInput, error) {
-		in.Name = "modified-" + in.Name
-		in.Count = in.Count * 10
-		return in, nil
-	})
+	)
 
-	body, _ := json.Marshal(testInput{Name: "original", Count: 3})
+	body, _ := json.Marshal(entryInput{Name: "original", Count: 3})
 	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
@@ -1240,18 +1293,14 @@ func TestHandler_OnEntry(t *testing.T) {
 }
 
 func TestHandler_OnSend(t *testing.T) {
-	handler := NewHandler[NoBody, testOutput](
+	handler := NewHandler[NoBody, sendOutput](
 		"test",
 		"GET",
 		"/test",
-		func(_ *Request[NoBody]) (testOutput, error) {
-			return testOutput{Message: "hello", Result: 5}, nil
+		func(_ *Request[NoBody]) (sendOutput, error) {
+			return sendOutput{Message: "hello", Result: 5}, nil
 		},
-	).OnSend(func(out testOutput) (testOutput, error) {
-		out.Message = out.Message + "-transformed"
-		out.Result = out.Result * 2
-		return out, nil
-	})
+	)
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	w := httptest.NewRecorder()
@@ -1261,7 +1310,7 @@ func TestHandler_OnSend(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var output testOutput
+	var output sendOutput
 	json.Unmarshal(w.Body.Bytes(), &output)
 
 	if output.Message != "hello-transformed" {
@@ -1272,79 +1321,17 @@ func TestHandler_OnSend(t *testing.T) {
 	}
 }
 
-func TestHandler_OnEntry_MultipleHooks(t *testing.T) {
-	handler := NewHandler[testInput, testOutput](
-		"test",
-		"POST",
-		"/test",
-		func(req *Request[testInput]) (testOutput, error) {
-			return testOutput{Message: req.Body.Name}, nil
-		},
-	).OnEntry(func(in testInput) (testInput, error) {
-		in.Name = in.Name + "-first"
-		return in, nil
-	}).OnEntry(func(in testInput) (testInput, error) {
-		in.Name = in.Name + "-second"
-		return in, nil
-	})
-
-	body, _ := json.Marshal(testInput{Name: "start"})
-	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
-	w := httptest.NewRecorder()
-
-	handler.Process(context.Background(), req, w)
-
-	var output testOutput
-	json.Unmarshal(w.Body.Bytes(), &output)
-
-	if output.Message != "start-first-second" {
-		t.Errorf("expected 'start-first-second', got %q", output.Message)
-	}
-}
-
-func TestHandler_OnSend_MultipleHooks(t *testing.T) {
-	handler := NewHandler[NoBody, testOutput](
-		"test",
-		"GET",
-		"/test",
-		func(_ *Request[NoBody]) (testOutput, error) {
-			return testOutput{Result: 1}, nil
-		},
-	).OnSend(func(out testOutput) (testOutput, error) {
-		out.Result = out.Result + 10
-		return out, nil
-	}).OnSend(func(out testOutput) (testOutput, error) {
-		out.Result = out.Result * 2
-		return out, nil
-	})
-
-	req := httptest.NewRequest("GET", "/test", nil)
-	w := httptest.NewRecorder()
-
-	handler.Process(context.Background(), req, w)
-
-	var output testOutput
-	json.Unmarshal(w.Body.Bytes(), &output)
-
-	// (1 + 10) * 2 = 22
-	if output.Result != 22 {
-		t.Errorf("expected 22, got %d", output.Result)
-	}
-}
-
 func TestHandler_OnEntry_Error(t *testing.T) {
-	handler := NewHandler[testInput, testOutput](
+	handler := NewHandler[entryInputError, testOutput](
 		"test",
 		"POST",
 		"/test",
-		func(_ *Request[testInput]) (testOutput, error) {
+		func(_ *Request[entryInputError]) (testOutput, error) {
 			return testOutput{Message: "should not reach"}, nil
 		},
-	).OnEntry(func(in testInput) (testInput, error) {
-		return in, errors.New("entry hook failed")
-	})
+	)
 
-	body, _ := json.Marshal(testInput{Name: "test"})
+	body, _ := json.Marshal(entryInputError{Name: "test"})
 	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
@@ -1359,16 +1346,14 @@ func TestHandler_OnEntry_Error(t *testing.T) {
 }
 
 func TestHandler_OnSend_Error(t *testing.T) {
-	handler := NewHandler[NoBody, testOutput](
+	handler := NewHandler[NoBody, sendOutputError](
 		"test",
 		"GET",
 		"/test",
-		func(_ *Request[NoBody]) (testOutput, error) {
-			return testOutput{Message: "hello"}, nil
+		func(_ *Request[NoBody]) (sendOutputError, error) {
+			return sendOutputError{Message: "hello"}, nil
 		},
-	).OnSend(func(out testOutput) (testOutput, error) {
-		return out, errors.New("send hook failed")
-	})
+	)
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	w := httptest.NewRecorder()
@@ -1383,39 +1368,31 @@ func TestHandler_OnSend_Error(t *testing.T) {
 	}
 }
 
-func TestHandler_OnEntry_Chaining(t *testing.T) {
-	handler := NewHandler[NoBody, testOutput](
+func TestHandler_OnEntry_ReceivesContext(t *testing.T) {
+	handler := NewHandler[entryCtxInput, testOutput](
 		"test",
-		"GET",
+		"POST",
 		"/test",
-		func(_ *Request[NoBody]) (testOutput, error) {
-			return testOutput{}, nil
+		func(req *Request[entryCtxInput]) (testOutput, error) {
+			return testOutput{Message: req.Body.Name}, nil
 		},
-	).OnEntry(func(in NoBody) (NoBody, error) {
-		return in, nil
-	}).WithSummary("Test")
+	)
 
-	spec := handler.Spec()
-	if spec.Summary != "Test" {
-		t.Errorf("expected summary 'Test', got %q", spec.Summary)
+	body, _ := json.Marshal(entryCtxInput{Name: "original"})
+	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	ctx := context.WithValue(context.Background(), entryCtxKey{}, "from-context")
+	_, err := handler.Process(ctx, req, w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-}
 
-func TestHandler_OnSend_Chaining(t *testing.T) {
-	handler := NewHandler[NoBody, testOutput](
-		"test",
-		"GET",
-		"/test",
-		func(_ *Request[NoBody]) (testOutput, error) {
-			return testOutput{}, nil
-		},
-	).OnSend(func(out testOutput) (testOutput, error) {
-		return out, nil
-	}).WithSummary("Test")
+	var output testOutput
+	json.Unmarshal(w.Body.Bytes(), &output)
 
-	spec := handler.Spec()
-	if spec.Summary != "Test" {
-		t.Errorf("expected summary 'Test', got %q", spec.Summary)
+	if output.Message != "from-context-original" {
+		t.Errorf("expected 'from-context-original', got %q", output.Message)
 	}
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -1,0 +1,15 @@
+package rocco
+
+import "context"
+
+// Entryable is implemented by input types that transform themselves before handler execution.
+// Hooks run after body parsing and validation, before the handler function.
+type Entryable interface {
+	OnEntry(ctx context.Context) error
+}
+
+// Sendable is implemented by output types that transform themselves before marshaling.
+// Hooks run after the handler function, before output validation and marshaling.
+type Sendable interface {
+	OnSend(ctx context.Context) error
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `Entryable` and `Sendable` interfaces enabling opt-in input/output transformations with context support.

* **Breaking Changes**
  * Removed `OnEntry()` and `OnSend()` methods from Handler; use `Entryable` and `Sendable` interfaces instead.

* **Documentation**
  * Updated handlers guide with new interface-based hook pattern, context usage examples, and updated comparison tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->