### PR TITLE
Refactor error OpenAPI schema generation

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -604,15 +604,29 @@ func (e *Engine) GenerateOpenAPI(identity Identity) *openapi.OpenAPI {
 		}
 	}
 
-	// Add base ErrorResponse schema (used for untyped errors like 500)
-	spec.Components.Schemas["ErrorResponse"] = &openapi.Schema{
-		Type: openapi.NewSchemaType("object"),
-		Properties: map[string]*openapi.Schema{
-			"code":    {Type: openapi.NewSchemaType("string"), Description: "Machine-readable error code"},
+	// Generate typed error response schemas from collected error definitions
+	for code, errDef := range errorDefs {
+		detailsMeta := errDef.DetailsMeta()
+		schemaName := "Err" + errorCodeToSchemaName(code)
+
+		// Build properties for the error response
+		properties := map[string]*openapi.Schema{
+			"code":    {Type: openapi.NewSchemaType("string"), Const: code, Description: "Machine-readable error code"},
 			"message": {Type: openapi.NewSchemaType("string"), Description: "Human-readable error message"},
-			"details": {Type: openapi.NewSchemaType("object"), Description: "Optional additional error details"},
-		},
-		Required: []string{"code", "message"},
+		}
+
+		// Inline details fields directly on the error schema
+		if detailsMeta.TypeName != "" && detailsMeta.TypeName != "NoDetails" {
+			detailsSchema := metadataToSchema(detailsMeta)
+			properties["details"] = detailsSchema
+		}
+
+		// Create the typed error response schema
+		spec.Components.Schemas[schemaName] = &openapi.Schema{
+			Type:       openapi.NewSchemaType("object"),
+			Properties: properties,
+			Required:   []string{"code", "message"},
+		}
 	}
 
 	// Track unique schemas to add to components
@@ -637,34 +651,6 @@ func (e *Engine) GenerateOpenAPI(identity Identity) *openapi.OpenAPI {
 			if relMeta, found := sentinel.Lookup(rel.To); found {
 				collectSchemas(relMeta)
 			}
-		}
-	}
-
-	// Generate typed error response schemas from collected error definitions
-	for code, errDef := range errorDefs {
-		detailsMeta := errDef.DetailsMeta()
-		schemaName := errorCodeToSchemaName(code) + "ErrorResponse"
-
-		// Build properties for the error response
-		properties := map[string]*openapi.Schema{
-			"code":    {Type: openapi.NewSchemaType("string"), Description: "Machine-readable error code"},
-			"message": {Type: openapi.NewSchemaType("string"), Description: "Human-readable error message"},
-		}
-
-		// Add typed details if the error has a details type
-		if detailsMeta.TypeName != "" && detailsMeta.TypeName != "NoDetails" {
-			// Collect the details schema
-			collectSchemas(detailsMeta)
-			properties["details"] = &openapi.Schema{
-				Ref: "#/components/schemas/" + detailsMeta.TypeName,
-			}
-		}
-
-		// Create the typed error response schema
-		spec.Components.Schemas[schemaName] = &openapi.Schema{
-			Type:       openapi.NewSchemaType("object"),
-			Properties: properties,
-			Required:   []string{"code", "message"},
 		}
 	}
 
@@ -770,7 +756,7 @@ func (e *Engine) GenerateOpenAPI(identity Identity) *openapi.OpenAPI {
 
 		// Add error responses from handler's declared error definitions
 		for _, errDef := range handler.ErrorDefs() {
-			schemaName := errorCodeToSchemaName(errDef.Code()) + "ErrorResponse"
+			schemaName := "Err" + errorCodeToSchemaName(errDef.Code())
 			operation.Responses[fmt.Sprintf("%d", errDef.Status())] = openapi.Response{
 				Description: statusCodeToResponseName(errDef.Status()),
 				Content: map[string]openapi.MediaType{
@@ -792,28 +778,6 @@ func (e *Engine) GenerateOpenAPI(identity Identity) *openapi.OpenAPI {
 			operation.Security = append(operation.Security, openapi.SecurityRequirement{
 				"bearerAuth": allScopes, // Scopes for OAuth2/bearer tokens
 			})
-
-			// Add 401 Unauthorized error response
-			operation.Responses["401"] = openapi.Response{
-				Description: "Unauthorized",
-				Content: map[string]openapi.MediaType{
-					ContentTypeJSON: {
-						Schema: &openapi.Schema{Ref: "#/components/schemas/ErrorResponse"},
-					},
-				},
-			}
-
-			// Add 403 Forbidden error response if handler has scope/role requirements
-			if len(handlerSpec.ScopeGroups) > 0 || len(handlerSpec.RoleGroups) > 0 {
-				operation.Responses["403"] = openapi.Response{
-					Description: "Forbidden - insufficient permissions",
-					Content: map[string]openapi.MediaType{
-						ContentTypeJSON: {
-							Schema: &openapi.Schema{Ref: "#/components/schemas/ErrorResponse"},
-						},
-					},
-				}
-			}
 		}
 
 		// Set operation on path item

--- a/docs/3.guides/4.openapi.md
+++ b/docs/3.guides/4.openapi.md
@@ -237,13 +237,13 @@ responses:
     content:
       application/json:
         schema:
-          $ref: '#/components/schemas/ErrorResponse_NotFoundDetails'
+          $ref: '#/components/schemas/ErrNotFound'
   409:
     description: Conflict
     content:
       application/json:
         schema:
-          $ref: '#/components/schemas/ErrorResponse_ConflictDetails'
+          $ref: '#/components/schemas/ErrConflict'
 ```
 
 ### Custom Error Schemas
@@ -261,7 +261,7 @@ var ErrInsufficientFunds = rocco.NewError[InsufficientFundsDetails](
 handler.WithErrors(ErrInsufficientFunds)
 ```
 
-The details type generates a schema component.
+The details fields are inlined directly on the error schema as the `details` property.
 
 ## Parameters
 

--- a/docs_test.go
+++ b/docs_test.go
@@ -305,17 +305,179 @@ func TestGenerateOpenAPI(t *testing.T) {
 		t.Error("expected schemas in components")
 	}
 
-	// Check standard error response schema
-	if _, exists := spec.Components.Schemas["ErrorResponse"]; !exists {
-		t.Error("expected ErrorResponse schema")
+	// Check typed error schemas from declared errors
+	if _, exists := spec.Components.Schemas["ErrBadRequest"]; !exists {
+		t.Error("expected ErrBadRequest schema")
+	}
+	if _, exists := spec.Components.Schemas["ErrNotFound"]; !exists {
+		t.Error("expected ErrNotFound schema")
+	}
+}
+
+func TestGenerateOpenAPI_ErrorSchemaStructure(t *testing.T) {
+	engine := newTestEngine()
+
+	handler := NewHandler[NoBody, testOutput](
+		"get-test",
+		"GET",
+		"/test",
+		func(req *Request[NoBody]) (testOutput, error) {
+			return testOutput{}, nil
+		},
+	).WithErrors(ErrBadRequest, ErrNotFound)
+
+	engine.WithHandlers(handler)
+	spec := engine.GenerateOpenAPI(nil)
+
+	t.Run("code field has const value", func(t *testing.T) {
+		schema := spec.Components.Schemas["ErrBadRequest"]
+		if schema == nil {
+			t.Fatal("expected ErrBadRequest schema")
+		}
+		codeSchema := schema.Properties["code"]
+		if codeSchema == nil {
+			t.Fatal("expected code property")
+		}
+		if codeSchema.Const != "BAD_REQUEST" {
+			t.Errorf("expected code const 'BAD_REQUEST', got %v", codeSchema.Const)
+		}
+
+		schema = spec.Components.Schemas["ErrNotFound"]
+		if schema == nil {
+			t.Fatal("expected ErrNotFound schema")
+		}
+		codeSchema = schema.Properties["code"]
+		if codeSchema == nil {
+			t.Fatal("expected code property")
+		}
+		if codeSchema.Const != "NOT_FOUND" {
+			t.Errorf("expected code const 'NOT_FOUND', got %v", codeSchema.Const)
+		}
+	})
+
+	t.Run("required fields", func(t *testing.T) {
+		schema := spec.Components.Schemas["ErrBadRequest"]
+		if schema == nil {
+			t.Fatal("expected ErrBadRequest schema")
+		}
+		hasCode, hasMessage := false, false
+		for _, r := range schema.Required {
+			if r == "code" {
+				hasCode = true
+			}
+			if r == "message" {
+				hasMessage = true
+			}
+		}
+		if !hasCode || !hasMessage {
+			t.Errorf("expected code and message in required, got %v", schema.Required)
+		}
+	})
+
+	t.Run("details inlined as object", func(t *testing.T) {
+		schema := spec.Components.Schemas["ErrNotFound"]
+		if schema == nil {
+			t.Fatal("expected ErrNotFound schema")
+		}
+		details := schema.Properties["details"]
+		if details == nil {
+			t.Fatal("expected details property")
+		}
+		if details.Ref != "" {
+			t.Errorf("expected details to be inlined, got $ref %q", details.Ref)
+		}
+		if details.Type == nil || details.Type.String() != "object" {
+			t.Error("expected details to be an object type")
+		}
+		if _, exists := details.Properties["resource"]; !exists {
+			t.Error("expected details to have 'resource' property from NotFoundDetails")
+		}
+	})
+
+	t.Run("no separate details models registered", func(t *testing.T) {
+		for name := range spec.Components.Schemas {
+			if name == "BadRequestDetails" || name == "NotFoundDetails" {
+				t.Errorf("details type %q should not be registered as a separate schema", name)
+			}
+		}
+	})
+
+	t.Run("no base ErrorResponse schema", func(t *testing.T) {
+		if _, exists := spec.Components.Schemas["ErrorResponse"]; exists {
+			t.Error("ErrorResponse base schema should not be registered")
+		}
+	})
+}
+
+func TestGenerateOpenAPI_CustomErrorSchema(t *testing.T) {
+	type TeapotDetails struct {
+		TeaType string `json:"tea_type" description:"The type of tea requested"`
+		Temp    int    `json:"temp" description:"Temperature in celsius"`
 	}
 
-	// Check typed error schemas from declared errors
-	if _, exists := spec.Components.Schemas["BadRequestErrorResponse"]; !exists {
-		t.Error("expected BadRequestErrorResponse schema")
+	errTeapot := NewError[TeapotDetails]("TEAPOT", 418, "I'm a teapot")
+
+	engine := newTestEngine()
+	handler := NewHandler[NoBody, testOutput](
+		"brew",
+		"POST",
+		"/brew",
+		func(req *Request[NoBody]) (testOutput, error) {
+			return testOutput{}, nil
+		},
+	).WithErrors(errTeapot)
+
+	engine.WithHandlers(handler)
+	spec := engine.GenerateOpenAPI(nil)
+
+	schema := spec.Components.Schemas["ErrTeapot"]
+	if schema == nil {
+		t.Fatal("expected ErrTeapot schema")
 	}
-	if _, exists := spec.Components.Schemas["NotFoundErrorResponse"]; !exists {
-		t.Error("expected NotFoundErrorResponse schema")
+	if schema.Properties["code"].Const != "TEAPOT" {
+		t.Errorf("expected code const 'TEAPOT', got %v", schema.Properties["code"].Const)
+	}
+	details := schema.Properties["details"]
+	if details == nil {
+		t.Fatal("expected details property")
+	}
+	if _, exists := details.Properties["tea_type"]; !exists {
+		t.Error("expected details to have 'tea_type' property")
+	}
+	if _, exists := details.Properties["temp"]; !exists {
+		t.Error("expected details to have 'temp' property")
+	}
+}
+
+func TestGenerateOpenAPI_ErrorDeduplication(t *testing.T) {
+	engine := newTestEngine()
+
+	// Declare the same error twice via separate WithErrors calls
+	handler := NewHandler[NoBody, testOutput](
+		"test",
+		"GET",
+		"/test",
+		func(req *Request[NoBody]) (testOutput, error) {
+			return testOutput{}, nil
+		},
+	).WithErrors(ErrBadRequest).WithErrors(ErrBadRequest, ErrNotFound)
+
+	engine.WithHandlers(handler)
+	spec := engine.GenerateOpenAPI(nil)
+
+	// Should have exactly 2 error responses (400, 404) plus 200
+	pathItem := spec.Paths["/test"]
+	if pathItem.Get == nil {
+		t.Fatal("expected GET operation")
+	}
+	if len(pathItem.Get.Responses) != 3 {
+		t.Errorf("expected 3 responses (200, 400, 404), got %d", len(pathItem.Get.Responses))
+	}
+
+	// ErrorCodes on spec should also be deduplicated
+	handlerSpec := handler.Spec()
+	if len(handlerSpec.ErrorCodes) != 2 {
+		t.Errorf("expected 2 error codes, got %d", len(handlerSpec.ErrorCodes))
 	}
 }
 

--- a/handler.go
+++ b/handler.go
@@ -43,8 +43,8 @@ type Handler[In, Out any] struct {
 	InputMeta  sentinel.Metadata
 	OutputMeta sentinel.Metadata
 
-	// Error definitions with schemas for OpenAPI generation.
-	errorDefs []ErrorDefinition
+	// Error definitions with schemas for OpenAPI generation, keyed by error code.
+	errorDefs map[string]ErrorDefinition
 
 	// Validation flags (checked once at creation time).
 	inputValidatable  bool // True if In implements Validatable.
@@ -361,6 +361,7 @@ func NewHandler[In, Out any](name string, method, path string, fn func(*Request[
 		codec:             defaultCodec,
 		InputMeta:         inputMeta,
 		OutputMeta:        outputMeta,
+		errorDefs:         make(map[string]ErrorDefinition),
 		inputValidatable:  inputValidatable,
 		outputValidatable: outputValidatable,
 		inputEntryable:    inputEntryable,
@@ -479,9 +480,12 @@ func (h *Handler[In, Out]) WithResponseHeaders(headers map[string]string) *Handl
 // Undeclared errors will be converted to 500 Internal Server Error.
 // This is used for OpenAPI documentation generation with proper error schemas.
 func (h *Handler[In, Out]) WithErrors(errs ...ErrorDefinition) *Handler[In, Out] {
-	h.errorDefs = append(h.errorDefs, errs...)
-	// Also populate ErrorCodes for spec serialization
 	for _, err := range errs {
+		h.errorDefs[err.Code()] = err
+	}
+	// Rebuild ErrorCodes from deduplicated map
+	h.spec.ErrorCodes = make([]int, 0, len(h.errorDefs))
+	for _, err := range h.errorDefs {
 		h.spec.ErrorCodes = append(h.spec.ErrorCodes, err.Status())
 	}
 	return h
@@ -490,7 +494,11 @@ func (h *Handler[In, Out]) WithErrors(errs ...ErrorDefinition) *Handler[In, Out]
 // ErrorDefs returns the declared error definitions for this handler.
 // Used by OpenAPI generation to extract error schemas.
 func (h *Handler[In, Out]) ErrorDefs() []ErrorDefinition {
-	return h.errorDefs
+	defs := make([]ErrorDefinition, 0, len(h.errorDefs))
+	for _, def := range h.errorDefs {
+		defs = append(defs, def)
+	}
+	return defs
 }
 
 // WithMaxBodySize sets the maximum request body size in bytes for this handler.
@@ -601,12 +609,8 @@ type errorResponse struct {
 // isErrorDeclared checks if an error was declared via WithErrors.
 // Matches by error code (e.g., "NOT_FOUND"), not just status code.
 func (h *Handler[In, Out]) isErrorDeclared(err ErrorDefinition) bool {
-	for _, declared := range h.errorDefs {
-		if declared.Code() == err.Code() {
-			return true
-		}
-	}
-	return false
+	_, exists := h.errorDefs[err.Code()]
+	return exists
 }
 
 // writeError writes a structured error response using the specified content type.

--- a/stream.go
+++ b/stream.go
@@ -124,7 +124,7 @@ type StreamHandler[In, Out any] struct {
 	OutputMeta sentinel.Metadata
 
 	// Error definitions with schemas for OpenAPI generation.
-	errorDefs []ErrorDefinition
+	errorDefs map[string]ErrorDefinition
 
 	// Validation flag (checked once at creation time).
 	inputValidatable bool // True if In implements Validatable.
@@ -286,7 +286,11 @@ func (h *StreamHandler[In, Out]) Spec() HandlerSpec {
 
 // ErrorDefs implements Endpoint.
 func (h *StreamHandler[In, Out]) ErrorDefs() []ErrorDefinition {
-	return h.errorDefs
+	defs := make([]ErrorDefinition, 0, len(h.errorDefs))
+	for _, def := range h.errorDefs {
+		defs = append(defs, def)
+	}
+	return defs
 }
 
 // Middleware implements Endpoint.
@@ -327,6 +331,7 @@ func NewStreamHandler[In, Out any](name string, method, path string, fn func(*Re
 			Tags:           []string{},
 			IsStream:       true,
 		},
+		errorDefs:        make(map[string]ErrorDefinition),
 		InputMeta:        inputMeta,
 		OutputMeta:       outputMeta,
 		inputValidatable: inputValidatable,
@@ -367,8 +372,12 @@ func (h *StreamHandler[In, Out]) WithQueryParams(params ...string) *StreamHandle
 // WithErrors declares which errors this handler may return.
 // Note: Errors can only be returned before the stream starts.
 func (h *StreamHandler[In, Out]) WithErrors(errs ...ErrorDefinition) *StreamHandler[In, Out] {
-	h.errorDefs = append(h.errorDefs, errs...)
 	for _, err := range errs {
+		h.errorDefs[err.Code()] = err
+	}
+	// Rebuild ErrorCodes from deduplicated map
+	h.spec.ErrorCodes = make([]int, 0, len(h.errorDefs))
+	for _, err := range h.errorDefs {
 		h.spec.ErrorCodes = append(h.spec.ErrorCodes, err.Status())
 	}
 	return h


### PR DESCRIPTION
  - Rename error schemas from {Code}ErrorResponse to Err{Code} prefix for alphabetical grouping in specs
  - Inline error details as properties on error schemas instead of registering them as separate $ref models
  - Add const values on error code fields (e.g. code: "BAD_REQUEST")
  - Remove base ErrorResponse schema; all errors use typed schemas
  - Change errorDefs storage from slice to map keyed by error code, enabling natural deduplication and override semantics
  - Remove implicit 401/403 error injection from auth block; handlers must explicitly declare errors via WithErrors
  - Update docs and tests to reflect new schema naming and structure



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Error schemas in OpenAPI documentation are now individually typed with clearer structure and inlined error details.

* **Documentation**
  * Updated OpenAPI guides to reflect new error schema references and details documentation.

* **Tests**
  * Enhanced test coverage for error schema generation, validation, and deduplication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->