### PR TITLE
fix: submodule release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # PAT required to push tags referencing commits with workflow changes
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Get release version
         id: version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow permissions to allow creation/pushing of tags that reference commits touching release-related workflows, improving tag management during releases and submodule tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->