### PR TITLE
feat: model registration and discriminated unions

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -430,7 +430,9 @@ func buildDiscriminatedUnionSchema(propName string, discriminateTag string, disc
 }
 
 // resolveTypeName finds a sentinel Metadata entry by short type name,
-// searching all cached FQDNs for a suffix match.
+// searching all cached FQDNs for a suffix match. If multiple packages
+// register types with the same short name, the first match wins —
+// short names must be unique across packages for deterministic results.
 func resolveTypeName(shortName string) (sentinel.Metadata, bool) {
 	suffix := "." + shortName
 	for _, fqdn := range sentinel.Browse() {

--- a/docs.go
+++ b/docs.go
@@ -16,6 +16,9 @@ func init() {
 	// Documentation-only tags
 	sentinel.Tag("example")
 	sentinel.Tag("description")
+	// Discriminated union tags
+	sentinel.Tag("discriminator")
+	sentinel.Tag("discriminate")
 }
 
 // parseFloat64 parses a string to *float64
@@ -347,6 +350,17 @@ func metadataToSchema(meta sentinel.Metadata) *openapi.Schema {
 		Properties: make(map[string]*openapi.Schema),
 	}
 
+	// First pass: collect discriminator mappings.
+	// discriminator:"fieldName" declares "I am the discriminator for fieldName"
+	// and provides the propertyName via its own json tag.
+	discriminators := make(map[string]string) // target field name -> discriminator json name
+	for _, field := range meta.Fields {
+		if target, ok := field.Tags["discriminator"]; ok && target != "" {
+			jsonName, _ := parseJSONTag(field)
+			discriminators[target] = jsonName
+		}
+	}
+
 	var required []string
 
 	for _, field := range meta.Fields {
@@ -357,8 +371,15 @@ func metadataToSchema(meta sentinel.Metadata) *openapi.Schema {
 			continue
 		}
 
-		// Convert field type to schema
-		fieldSchema := goTypeToSchema(field.Type)
+		var fieldSchema *openapi.Schema
+
+		// Check for discriminate tag — this field is a union
+		if discriminateTag, ok := field.Tags["discriminate"]; ok && discriminateTag != "" {
+			fieldSchema = buildDiscriminatedUnionSchema(propName, discriminateTag, discriminators)
+		} else {
+			// Convert field type to schema
+			fieldSchema = goTypeToSchema(field.Type)
+		}
 
 		// Apply OpenAPI tags to field schema
 		applyOpenAPITags(fieldSchema, field)
@@ -375,6 +396,49 @@ func metadataToSchema(meta sentinel.Metadata) *openapi.Schema {
 	}
 
 	return schema
+}
+
+// buildDiscriminatedUnionSchema creates a oneOf schema with discriminator for a union field.
+func buildDiscriminatedUnionSchema(propName string, discriminateTag string, discriminators map[string]string) *openapi.Schema {
+	typeNames := strings.Split(discriminateTag, ",")
+	oneOf := make([]*openapi.Schema, 0, len(typeNames))
+	mapping := make(map[string]string, len(typeNames))
+
+	for _, typeName := range typeNames {
+		typeName = strings.TrimSpace(typeName)
+		if typeName == "" {
+			continue
+		}
+		ref := "#/components/schemas/" + typeName
+		oneOf = append(oneOf, &openapi.Schema{Ref: ref})
+		mapping[typeName] = ref
+	}
+
+	schema := &openapi.Schema{
+		OneOf: oneOf,
+	}
+
+	// Attach discriminator if a paired discriminator tag targets this field
+	if discriminatorPropName, ok := discriminators[propName]; ok {
+		schema.Discriminator = &openapi.Discriminator{
+			PropertyName: discriminatorPropName,
+			Mapping:      mapping,
+		}
+	}
+
+	return schema
+}
+
+// resolveTypeName finds a sentinel Metadata entry by short type name,
+// searching all cached FQDNs for a suffix match.
+func resolveTypeName(shortName string) (sentinel.Metadata, bool) {
+	suffix := "." + shortName
+	for _, fqdn := range sentinel.Browse() {
+		if strings.HasSuffix(fqdn, suffix) {
+			return sentinel.Lookup(fqdn)
+		}
+	}
+	return sentinel.Metadata{}, false
 }
 
 // parseJSONTag extracts the JSON property name and determines if field is required
@@ -653,6 +717,26 @@ func (e *Engine) GenerateOpenAPI(identity Identity) *openapi.OpenAPI {
 				collectSchemas(relMeta)
 			}
 		}
+
+		// Discover types referenced by discriminate tags
+		for _, field := range meta.Fields {
+			if discriminateTag, ok := field.Tags["discriminate"]; ok && discriminateTag != "" {
+				for _, name := range strings.Split(discriminateTag, ",") {
+					name = strings.TrimSpace(name)
+					if name == "" || processedTypes[name] {
+						continue
+					}
+					if relMeta, found := resolveTypeName(name); found {
+						collectSchemas(relMeta)
+					}
+				}
+			}
+		}
+	}
+
+	// Collect standalone model schemas
+	for _, model := range e.models {
+		collectSchemas(model.meta)
 	}
 
 	// Iterate over registered handlers

--- a/docs/2.learn/2.concepts.md
+++ b/docs/2.learn/2.concepts.md
@@ -38,6 +38,7 @@ engine.Start(rocco.HostAll, 8080)
 | `WithAuthenticator(extractor)` | Configure identity extraction for authentication |
 | `WithMiddleware(mw...)` | Add global middleware |
 | `WithHandlers(handlers...)` | Register handlers |
+| `WithModels(models...)` | Register standalone types for OpenAPI schemas |
 | `WithSpec(spec)` | Configure OpenAPI metadata |
 | `Router()` | Access underlying stdlib ServeMux |
 | `Start(host, port)` | Begin serving requests |

--- a/docs/3.guides/4.openapi.md
+++ b/docs/3.guides/4.openapi.md
@@ -161,6 +161,17 @@ Examples are type-aware:
 - Boolean: `example:"true"` → `true`
 - Array: `example:"a,b,c"` → `["a", "b", "c"]`
 
+#### Discriminator Tag
+
+```go
+type Notification struct {
+    Type  string `json:"type" discriminator:"event"` // "I select for the event field"
+    Event any    `json:"event" discriminate:"TypeA,TypeB"` // "I am the union"
+}
+```
+
+See [Discriminated Unions](#discriminated-unions) for full details.
+
 ## Validation to OpenAPI Mapping
 
 The `validate` tag drives both runtime validation and OpenAPI constraints:
@@ -229,6 +240,73 @@ CreateUserInput:
       maxItems: 10
       uniqueItems: true
       description: User tags
+```
+
+## Standalone Models
+
+Types that aren't directly used as handler input or output can be registered as standalone models. This is required for discriminated unions and useful for any type you want in your OpenAPI component schemas.
+
+```go
+engine.WithModels(
+    rocco.NewModel[IngestCompletedEvent](),
+    rocco.NewModel[IngestFailedEvent](),
+)
+```
+
+## Discriminated Unions
+
+For polymorphic payloads where a type field determines the shape of a nested object, use the `discriminator` and `discriminate` struct tags together.
+
+### Tags
+
+- `discriminator:"fieldName"` on the selector field — declares "I select for this union field" and names the target
+- `discriminate:"TypeA,TypeB"` on the union field — declares "I am the union" and lists the possible schemas
+
+```go
+type Notification struct {
+    Type  string `json:"type" discriminator:"event"`
+    Event any    `json:"event" discriminate:"IngestCompletedEvent,IngestFailedEvent"`
+}
+
+type IngestCompletedEvent struct {
+    DocumentID   string `json:"document_id"`
+    DocumentName string `json:"document_name"`
+}
+
+type IngestFailedEvent struct {
+    DocumentID string `json:"document_id"`
+    Error      string `json:"error"`
+}
+```
+
+Register the variant types as standalone models so they appear in the spec:
+
+```go
+engine := rocco.NewEngine().
+    WithModels(
+        rocco.NewModel[IngestCompletedEvent](),
+        rocco.NewModel[IngestFailedEvent](),
+    ).
+    WithHandlers(notificationHandler)
+```
+
+### Generated Schema
+
+```yaml
+Notification:
+  type: object
+  properties:
+    type:
+      type: string
+    event:
+      oneOf:
+        - $ref: '#/components/schemas/IngestCompletedEvent'
+        - $ref: '#/components/schemas/IngestFailedEvent'
+      discriminator:
+        propertyName: type
+        mapping:
+          IngestCompletedEvent: '#/components/schemas/IngestCompletedEvent'
+          IngestFailedEvent: '#/components/schemas/IngestFailedEvent'
 ```
 
 ## Error Schemas

--- a/docs/3.guides/4.openapi.md
+++ b/docs/3.guides/4.openapi.md
@@ -259,7 +259,7 @@ For polymorphic payloads where a type field determines the shape of a nested obj
 
 ### Tags
 
-- `discriminator:"fieldName"` on the selector field — declares "I select for this union field" and names the target
+- `discriminator:"fieldName"` on the selector field — declares "I select for this union field" and names the **json property name** of the target union field (not the Go field name)
 - `discriminate:"TypeA,TypeB"` on the union field — declares "I am the union" and lists the possible schemas
 
 ```go
@@ -279,7 +279,7 @@ type IngestFailedEvent struct {
 }
 ```
 
-Register the variant types as standalone models so they appear in the spec:
+Register the variant types as standalone models to ensure they appear in the spec (this is only strictly necessary when the types aren't already scanned through handler input/output types):
 
 ```go
 engine := rocco.NewEngine().

--- a/docs/5.reference/1.api.md
+++ b/docs/5.reference/1.api.md
@@ -99,6 +99,14 @@ func (e *Engine) WithTagGroup(name string, tags ...string) *Engine
 
 Adds or updates a tag group for hierarchical tag organization. Rendered as the `x-tagGroups` vendor extension in the OpenAPI spec.
 
+#### WithModels
+
+```go
+func (e *Engine) WithModels(models ...*Model) *Engine
+```
+
+Registers standalone types into the OpenAPI component schemas. These types don't need to be handler input or output types — they are included in the spec for use by features like discriminated unions or external references. Returns engine for chaining.
+
 #### WithCodec
 
 ```go
@@ -533,6 +541,23 @@ type UsageLimit struct {
 ```
 
 Usage limit configuration for rate limiting.
+
+## Model
+
+### NewModel
+
+```go
+func NewModel[T any]() *Model
+```
+
+Scans T with sentinel and returns a Model for OpenAPI schema registration. Use with `Engine.WithModels()` to include types in the spec that aren't handler input or output types.
+
+```go
+engine.WithModels(
+    rocco.NewModel[IngestCompletedEvent](),
+    rocco.NewModel[IngestFailedEvent](),
+)
+```
 
 ## Codec
 

--- a/docs_test.go
+++ b/docs_test.go
@@ -1653,3 +1653,203 @@ func TestParseValidateTag_Combined(t *testing.T) {
 		t.Errorf("maximum = %v, want 100", *maxVal)
 	}
 }
+
+func TestBuildDiscriminatedUnionSchema(t *testing.T) {
+	discriminators := map[string]string{
+		"event": "type",
+	}
+
+	schema := buildDiscriminatedUnionSchema("event", "IngestCompletedEvent,IngestFailedEvent", discriminators)
+
+	t.Run("oneOf refs", func(t *testing.T) {
+		if len(schema.OneOf) != 2 {
+			t.Fatalf("expected 2 oneOf entries, got %d", len(schema.OneOf))
+		}
+		if schema.OneOf[0].Ref != "#/components/schemas/IngestCompletedEvent" {
+			t.Errorf("expected ref to IngestCompletedEvent, got %q", schema.OneOf[0].Ref)
+		}
+		if schema.OneOf[1].Ref != "#/components/schemas/IngestFailedEvent" {
+			t.Errorf("expected ref to IngestFailedEvent, got %q", schema.OneOf[1].Ref)
+		}
+	})
+
+	t.Run("discriminator", func(t *testing.T) {
+		if schema.Discriminator == nil {
+			t.Fatal("expected discriminator to be set")
+		}
+		if schema.Discriminator.PropertyName != "type" {
+			t.Errorf("expected propertyName 'type', got %q", schema.Discriminator.PropertyName)
+		}
+		if len(schema.Discriminator.Mapping) != 2 {
+			t.Fatalf("expected 2 mapping entries, got %d", len(schema.Discriminator.Mapping))
+		}
+		if schema.Discriminator.Mapping["IngestCompletedEvent"] != "#/components/schemas/IngestCompletedEvent" {
+			t.Errorf("unexpected mapping for IngestCompletedEvent: %q", schema.Discriminator.Mapping["IngestCompletedEvent"])
+		}
+	})
+}
+
+func TestBuildDiscriminatedUnionSchema_NoDiscriminator(t *testing.T) {
+	// When no discriminator tag targets this field, discriminator should be nil
+	schema := buildDiscriminatedUnionSchema("event", "TypeA,TypeB", map[string]string{})
+
+	if len(schema.OneOf) != 2 {
+		t.Fatalf("expected 2 oneOf entries, got %d", len(schema.OneOf))
+	}
+	if schema.Discriminator != nil {
+		t.Error("expected discriminator to be nil when no discriminator tag targets this field")
+	}
+}
+
+func TestMetadataToSchema_DiscriminatedUnion(t *testing.T) {
+	meta := sentinel.Metadata{
+		TypeName: "Notification",
+		Fields: []sentinel.FieldMetadata{
+			{
+				Name: "Type",
+				Type: "string",
+				Tags: map[string]string{
+					"json":          "type",
+					"discriminator": "event",
+				},
+			},
+			{
+				Name: "Event",
+				Type: "any",
+				Tags: map[string]string{
+					"json":          "event",
+					"discriminate":  "IngestCompletedEvent,IngestFailedEvent",
+				},
+			},
+		},
+	}
+
+	schema := metadataToSchema(meta)
+
+	t.Run("type field is normal string", func(t *testing.T) {
+		typeProp := schema.Properties["type"]
+		if typeProp == nil {
+			t.Fatal("expected 'type' property")
+		}
+		if typeProp.Type == nil || typeProp.Type.String() != "string" {
+			t.Errorf("expected string type, got %v", typeProp.Type)
+		}
+	})
+
+	t.Run("event field is oneOf with discriminator", func(t *testing.T) {
+		eventProp := schema.Properties["event"]
+		if eventProp == nil {
+			t.Fatal("expected 'event' property")
+		}
+		if len(eventProp.OneOf) != 2 {
+			t.Fatalf("expected 2 oneOf entries, got %d", len(eventProp.OneOf))
+		}
+		if eventProp.OneOf[0].Ref != "#/components/schemas/IngestCompletedEvent" {
+			t.Errorf("expected ref to IngestCompletedEvent, got %q", eventProp.OneOf[0].Ref)
+		}
+		if eventProp.Discriminator == nil {
+			t.Fatal("expected discriminator")
+		}
+		if eventProp.Discriminator.PropertyName != "type" {
+			t.Errorf("expected propertyName 'type', got %q", eventProp.Discriminator.PropertyName)
+		}
+	})
+
+	t.Run("both fields required", func(t *testing.T) {
+		if len(schema.Required) != 2 {
+			t.Errorf("expected 2 required fields, got %v", schema.Required)
+		}
+	})
+}
+
+func TestResolveTypeName(t *testing.T) {
+	// Scan a type so it's in sentinel's cache
+	_ = NewModel[testModelType]()
+
+	meta, found := resolveTypeName("testModelType")
+	if !found {
+		t.Fatal("expected to find testModelType via resolveTypeName")
+	}
+	if meta.TypeName != "testModelType" {
+		t.Errorf("expected type name 'testModelType', got %q", meta.TypeName)
+	}
+}
+
+func TestResolveTypeName_NotFound(t *testing.T) {
+	_, found := resolveTypeName("NonExistentType12345")
+	if found {
+		t.Error("expected resolveTypeName to return false for non-existent type")
+	}
+}
+
+func TestGenerateOpenAPI_DiscriminatedUnion(t *testing.T) {
+	type IngestCompletedEvent struct {
+		DocumentID   string `json:"document_id"`
+		DocumentName string `json:"document_name"`
+	}
+
+	type IngestFailedEvent struct {
+		DocumentID string `json:"document_id"`
+		Error      string `json:"error"`
+	}
+
+	type Notification struct {
+		Type  string `json:"type" discriminator:"event"`
+		Event any    `json:"event" discriminate:"IngestCompletedEvent,IngestFailedEvent"`
+	}
+
+	engine := newTestEngine()
+	engine.WithModels(
+		NewModel[IngestCompletedEvent](),
+		NewModel[IngestFailedEvent](),
+	)
+
+	handler := NewHandler[NoBody, Notification](
+		"get-notification",
+		"GET",
+		"/notifications/{id}",
+		func(req *Request[NoBody]) (Notification, error) {
+			return Notification{}, nil
+		},
+	).WithPathParams("id")
+
+	engine.WithHandlers(handler)
+	spec := engine.GenerateOpenAPI(nil)
+
+	t.Run("variant schemas registered", func(t *testing.T) {
+		if _, exists := spec.Components.Schemas["IngestCompletedEvent"]; !exists {
+			t.Error("expected IngestCompletedEvent in component schemas")
+		}
+		if _, exists := spec.Components.Schemas["IngestFailedEvent"]; !exists {
+			t.Error("expected IngestFailedEvent in component schemas")
+		}
+	})
+
+	t.Run("notification schema has oneOf", func(t *testing.T) {
+		notif := spec.Components.Schemas["Notification"]
+		if notif == nil {
+			t.Fatal("expected Notification schema")
+		}
+		eventProp := notif.Properties["event"]
+		if eventProp == nil {
+			t.Fatal("expected 'event' property on Notification")
+		}
+		if len(eventProp.OneOf) != 2 {
+			t.Fatalf("expected 2 oneOf entries, got %d", len(eventProp.OneOf))
+		}
+	})
+
+	t.Run("discriminator set correctly", func(t *testing.T) {
+		notif := spec.Components.Schemas["Notification"]
+		eventProp := notif.Properties["event"]
+		if eventProp.Discriminator == nil {
+			t.Fatal("expected discriminator on event property")
+		}
+		if eventProp.Discriminator.PropertyName != "type" {
+			t.Errorf("expected propertyName 'type', got %q", eventProp.Discriminator.PropertyName)
+		}
+		if len(eventProp.Discriminator.Mapping) != 2 {
+			t.Errorf("expected 2 mapping entries, got %d", len(eventProp.Discriminator.Mapping))
+		}
+	})
+}

--- a/docs_test.go
+++ b/docs_test.go
@@ -1701,6 +1701,21 @@ func TestBuildDiscriminatedUnionSchema_NoDiscriminator(t *testing.T) {
 	}
 }
 
+func TestBuildDiscriminatedUnionSchema_EmptyTypeNames(t *testing.T) {
+	// Empty and whitespace-only type names should be skipped
+	schema := buildDiscriminatedUnionSchema("event", "TypeA, ,TypeB, ", map[string]string{})
+
+	if len(schema.OneOf) != 2 {
+		t.Fatalf("expected 2 oneOf entries (empty names skipped), got %d", len(schema.OneOf))
+	}
+	if schema.OneOf[0].Ref != "#/components/schemas/TypeA" {
+		t.Errorf("expected ref to TypeA, got %q", schema.OneOf[0].Ref)
+	}
+	if schema.OneOf[1].Ref != "#/components/schemas/TypeB" {
+		t.Errorf("expected ref to TypeB, got %q", schema.OneOf[1].Ref)
+	}
+}
+
 func TestMetadataToSchema_DiscriminatedUnion(t *testing.T) {
 	meta := sentinel.Metadata{
 		TypeName: "Notification",
@@ -1779,6 +1794,45 @@ func TestResolveTypeName_NotFound(t *testing.T) {
 	_, found := resolveTypeName("NonExistentType12345")
 	if found {
 		t.Error("expected resolveTypeName to return false for non-existent type")
+	}
+}
+
+func TestGenerateOpenAPI_DiscriminatedUnionAutoDiscovery(t *testing.T) {
+	// Variant types are scanned by sentinel (via NewModel) but NOT registered
+	// with WithModels. They should still be discovered via resolveTypeName
+	// when collectSchemas processes the discriminate tag on the parent type.
+	type AutoEventA struct {
+		Status string `json:"status"`
+	}
+	type AutoEventB struct {
+		Reason string `json:"reason"`
+	}
+	type AutoParent struct {
+		Kind    string `json:"kind" discriminator:"payload"`
+		Payload any    `json:"payload" discriminate:"AutoEventA,AutoEventB"`
+	}
+
+	// Scan types into sentinel cache without WithModels
+	_ = NewModel[AutoEventA]()
+	_ = NewModel[AutoEventB]()
+
+	engine := newTestEngine()
+	handler := NewHandler[NoBody, AutoParent](
+		"get-auto",
+		"GET",
+		"/auto",
+		func(req *Request[NoBody]) (AutoParent, error) {
+			return AutoParent{}, nil
+		},
+	)
+	engine.WithHandlers(handler)
+	spec := engine.GenerateOpenAPI(nil)
+
+	if _, exists := spec.Components.Schemas["AutoEventA"]; !exists {
+		t.Error("expected AutoEventA discovered via resolveTypeName")
+	}
+	if _, exists := spec.Components.Schemas["AutoEventB"]; !exists {
+		t.Error("expected AutoEventB discovered via resolveTypeName")
 	}
 }
 

--- a/engine.go
+++ b/engine.go
@@ -28,6 +28,7 @@ type Engine struct {
 	mux                 *http.ServeMux
 	globalMiddleware    []func(http.Handler) http.Handler
 	handlers            []Endpoint // Registered handlers for OpenAPI generation
+	models              []*Model   // Standalone models for OpenAPI schema generation
 	extractIdentity     func(context.Context, *http.Request) (Identity, error)
 	ctx                 context.Context
 	cancel              context.CancelFunc
@@ -139,6 +140,14 @@ func (e *Engine) WithTagGroup(name string, tags ...string) *Engine {
 // This allows power users to register custom routes that won't appear in OpenAPI documentation.
 func (e *Engine) Router() *http.ServeMux {
 	return e.mux
+}
+
+// WithModels registers standalone types into the OpenAPI component schemas.
+// These types don't need to be handler input or output types — they are included
+// in the spec for use by features like discriminated unions or external references.
+func (e *Engine) WithModels(models ...*Model) *Engine {
+	e.models = append(e.models, models...)
+	return e
 }
 
 // WithHandlers adds one or more Endpoints to the engine and returns the engine for chaining.

--- a/model.go
+++ b/model.go
@@ -1,0 +1,16 @@
+package rocco
+
+import "github.com/zoobz-io/sentinel"
+
+// Model holds sentinel metadata for a type that should appear in the OpenAPI
+// component schemas without being a handler input or output type.
+type Model struct {
+	meta sentinel.Metadata
+}
+
+// NewModel scans T with sentinel and returns a Model for schema registration.
+func NewModel[T any]() *Model {
+	return &Model{
+		meta: sentinel.Scan[T](),
+	}
+}

--- a/model_test.go
+++ b/model_test.go
@@ -1,0 +1,60 @@
+package rocco
+
+import (
+	"testing"
+)
+
+type testModelType struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestNewModel(t *testing.T) {
+	model := NewModel[testModelType]()
+
+	if model.meta.TypeName != "testModelType" {
+		t.Errorf("expected type name 'testModelType', got %q", model.meta.TypeName)
+	}
+	if len(model.meta.Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(model.meta.Fields))
+	}
+}
+
+func TestWithModels(t *testing.T) {
+	engine := newTestEngine()
+
+	engine.WithModels(
+		NewModel[testModelType](),
+	)
+
+	if len(engine.models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(engine.models))
+	}
+	if engine.models[0].meta.TypeName != "testModelType" {
+		t.Errorf("expected model type 'testModelType', got %q", engine.models[0].meta.TypeName)
+	}
+}
+
+func TestWithModels_AppearsInOpenAPI(t *testing.T) {
+	engine := newTestEngine()
+
+	engine.WithModels(
+		NewModel[testModelType](),
+	)
+
+	spec := engine.GenerateOpenAPI(nil)
+
+	schema, exists := spec.Components.Schemas["testModelType"]
+	if !exists {
+		t.Fatal("expected testModelType in component schemas")
+	}
+	if schema.Type == nil || schema.Type.String() != "object" {
+		t.Errorf("expected object type, got %v", schema.Type)
+	}
+	if _, exists := schema.Properties["id"]; !exists {
+		t.Error("expected 'id' property")
+	}
+	if _, exists := schema.Properties["name"]; !exists {
+		t.Error("expected 'name' property")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #22.

- Add `NewModel[T]()` and `Engine.WithModels()` for registering standalone types in OpenAPI component schemas that aren't handler In/Out types
- Add `discriminator` and `discriminate` struct tags for expressing `oneOf` + `discriminator` on polymorphic payloads
- Types listed in `discriminate` tags are auto-discovered via `sentinel.Browse()` for schema collection

## Usage

```go
engine := rocco.NewEngine().
    WithModels(
        rocco.NewModel[IngestCompletedEvent](),
        rocco.NewModel[IngestFailedEvent](),
    ).
    WithHandlers(notificationHandler)
```

```go
type Notification struct {
    Type  string `json:"type" discriminator:"event"`
    Event any    `json:"event" discriminate:"IngestCompletedEvent,IngestFailedEvent"`
}
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + 7 new tests)
- [ ] Verify generated OpenAPI spec renders correctly in Scalar/Redoc