### PR TITLE
fix: resolve nested types in error detail schemas

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -757,6 +757,20 @@ func (e *Engine) GenerateOpenAPI(identity Identity) *openapi.OpenAPI {
 		}
 	}
 
+	// Collect nested types referenced by error detail schemas.
+	// We don't call collectSchemas on the details type itself (it's inlined
+	// on the error schema), but we do need to collect its nested types.
+	for _, errDef := range errorDefs {
+		detailsMeta := errDef.DetailsMeta()
+		if detailsMeta.TypeName != "" && detailsMeta.TypeName != "NoDetails" {
+			for _, rel := range detailsMeta.Relationships {
+				if relMeta, found := sentinel.Lookup(rel.To); found {
+					collectSchemas(relMeta)
+				}
+			}
+		}
+	}
+
 	// Collect standalone model schemas
 	for _, model := range e.models {
 		if model.schema != nil {

--- a/docs_test.go
+++ b/docs_test.go
@@ -493,6 +493,48 @@ func TestGenerateOpenAPI_CustomErrorSchema(t *testing.T) {
 	}
 }
 
+func TestGenerateOpenAPI_ErrorDetailsNestedTypes(t *testing.T) {
+	type NestedField struct {
+		Code    string `json:"code" description:"Field error code"`
+		Message string `json:"message" description:"Field error message"`
+	}
+	type DetailsWithNested struct {
+		Fields []NestedField `json:"fields" description:"Per-field errors"`
+	}
+
+	errNested := NewError[DetailsWithNested]("NESTED_ERROR", 422, "has nested details")
+
+	engine := newTestEngine()
+	handler := NewHandler[NoBody, testOutput](
+		"nested",
+		"POST",
+		"/nested",
+		func(req *Request[NoBody]) (testOutput, error) {
+			return testOutput{}, nil
+		},
+	).WithErrors(errNested)
+
+	engine.WithHandlers(handler)
+	spec := engine.GenerateOpenAPI(nil)
+
+	// The nested type should be registered as a component schema
+	nestedSchema := spec.Components.Schemas["NestedField"]
+	if nestedSchema == nil {
+		t.Fatal("expected NestedField to be registered as a component schema")
+	}
+	if _, exists := nestedSchema.Properties["code"]; !exists {
+		t.Error("expected NestedField to have 'code' property")
+	}
+	if _, exists := nestedSchema.Properties["message"]; !exists {
+		t.Error("expected NestedField to have 'message' property")
+	}
+
+	// The details type itself should NOT be registered (it's inlined)
+	if _, exists := spec.Components.Schemas["DetailsWithNested"]; exists {
+		t.Error("details type should be inlined, not registered as a separate schema")
+	}
+}
+
 func TestGenerateOpenAPI_ErrorDeduplication(t *testing.T) {
 	engine := newTestEngine()
 


### PR DESCRIPTION
## Summary
- Error detail schemas that contain nested struct types (e.g. `ValidationDetails` with `Fields []ValidationFieldError`) now correctly register those nested types in `components/schemas`
- Walks relationships of error detail metadata through `collectSchemas` without registering the details type itself (since it's inlined on the error schema)
- Adds test coverage for nested error detail types

Closes #24

## Test plan
- [x] Existing tests pass
- [x] New `TestGenerateOpenAPI_ErrorDetailsNestedTypes` verifies nested types are registered and details type remains inlined

🤖 Generated with [Claude Code](https://claude.com/claude-code)