### PR TITLE
feat: enum models, schema models, and typed map values

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -487,6 +487,27 @@ func goTypeToSchema(goType string) *openapi.Schema {
 
 	// Handle maps
 	if strings.HasPrefix(goType, "map[") {
+		// Extract value type from map[K]V
+		// Find the closing bracket for the key type
+		depth := 0
+		valueStart := -1
+		for i, ch := range goType {
+			if ch == '[' {
+				depth++
+			} else if ch == ']' {
+				depth--
+				if depth == 0 {
+					valueStart = i + 1
+					break
+				}
+			}
+		}
+		if valueStart > 0 && valueStart < len(goType) {
+			return &openapi.Schema{
+				Type:                 openapi.NewSchemaType("object"),
+				AdditionalProperties: goTypeToSchema(goType[valueStart:]),
+			}
+		}
 		return &openapi.Schema{
 			Type:                 openapi.NewSchemaType("object"),
 			AdditionalProperties: true,
@@ -738,7 +759,12 @@ func (e *Engine) GenerateOpenAPI(identity Identity) *openapi.OpenAPI {
 
 	// Collect standalone model schemas
 	for _, model := range e.models {
-		collectSchemas(model.meta)
+		if model.schema != nil {
+			// Direct schema registration (enums, maps, arbitrary schemas)
+			schemas[model.name] = model.schema
+		} else {
+			collectSchemas(model.meta)
+		}
 	}
 
 	// Iterate over registered handlers

--- a/docs_test.go
+++ b/docs_test.go
@@ -140,6 +140,50 @@ func TestGoTypeToSchema(t *testing.T) {
 	}
 }
 
+func TestGoTypeToSchema_MapValueType(t *testing.T) {
+	t.Run("map[string]string", func(t *testing.T) {
+		schema := goTypeToSchema("map[string]string")
+		if schema.Type == nil || schema.Type.String() != "object" {
+			t.Errorf("expected object type, got %v", schema.Type)
+		}
+		ap, ok := schema.AdditionalProperties.(*openapi.Schema)
+		if !ok {
+			t.Fatal("expected additionalProperties to be a schema")
+		}
+		if ap.Type == nil || ap.Type.String() != "string" {
+			t.Errorf("expected string value type, got %v", ap.Type)
+		}
+	})
+
+	t.Run("map[string]SomeStruct", func(t *testing.T) {
+		schema := goTypeToSchema("map[string]SomeStruct")
+		if schema.Type == nil || schema.Type.String() != "object" {
+			t.Errorf("expected object type, got %v", schema.Type)
+		}
+		ap, ok := schema.AdditionalProperties.(*openapi.Schema)
+		if !ok {
+			t.Fatal("expected additionalProperties to be a schema")
+		}
+		if ap.Ref != "#/components/schemas/SomeStruct" {
+			t.Errorf("expected $ref to SomeStruct, got %q", ap.Ref)
+		}
+	})
+
+	t.Run("map[string][]int", func(t *testing.T) {
+		schema := goTypeToSchema("map[string][]int")
+		ap, ok := schema.AdditionalProperties.(*openapi.Schema)
+		if !ok {
+			t.Fatal("expected additionalProperties to be a schema")
+		}
+		if ap.Type == nil || ap.Type.String() != "array" {
+			t.Errorf("expected array value type, got %v", ap.Type)
+		}
+		if ap.Items == nil || ap.Items.Type == nil || ap.Items.Type.String() != "integer" {
+			t.Error("expected array items to be integer")
+		}
+	})
+}
+
 func TestGoTypeToSchema_ComplexType(t *testing.T) {
 	schema := goTypeToSchema("github.com/user/pkg.CustomType")
 

--- a/model.go
+++ b/model.go
@@ -1,16 +1,45 @@
 package rocco
 
-import "github.com/zoobz-io/sentinel"
+import (
+	"github.com/zoobz-io/openapi"
+	"github.com/zoobz-io/sentinel"
+)
 
-// Model holds sentinel metadata for a type that should appear in the OpenAPI
+// Model holds schema information for a type that should appear in the OpenAPI
 // component schemas without being a handler input or output type.
 type Model struct {
-	meta sentinel.Metadata
+	meta   sentinel.Metadata
+	name   string
+	schema *openapi.Schema
 }
 
 // NewModel scans T with sentinel and returns a Model for schema registration.
 func NewModel[T any]() *Model {
 	return &Model{
 		meta: sentinel.Scan[T](),
+	}
+}
+
+// NewEnumModel creates a Model for a string enum type with explicit values.
+func NewEnumModel[T ~string](name string, values ...T) *Model {
+	enumValues := make([]any, len(values))
+	for i, v := range values {
+		enumValues[i] = string(v)
+	}
+	return &Model{
+		name: name,
+		schema: &openapi.Schema{
+			Type: openapi.NewSchemaType("string"),
+			Enum: enumValues,
+		},
+	}
+}
+
+// NewSchemaModel creates a Model from an arbitrary OpenAPI schema.
+// This is an escape hatch for types that the typed constructors don't cover.
+func NewSchemaModel(name string, schema *openapi.Schema) *Model {
+	return &Model{
+		name:   name,
+		schema: schema,
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -2,6 +2,8 @@ package rocco
 
 import (
 	"testing"
+
+	"github.com/zoobz-io/openapi"
 )
 
 type testModelType struct {
@@ -56,5 +58,97 @@ func TestWithModels_AppearsInOpenAPI(t *testing.T) {
 	}
 	if _, exists := schema.Properties["name"]; !exists {
 		t.Error("expected 'name' property")
+	}
+}
+
+type ProviderType string
+
+const (
+	ProviderGoogleDrive ProviderType = "google_drive"
+	ProviderOneDrive    ProviderType = "onedrive"
+	ProviderDropbox     ProviderType = "dropbox"
+)
+
+func TestNewEnumModel(t *testing.T) {
+	model := NewEnumModel("ProviderType", ProviderGoogleDrive, ProviderOneDrive, ProviderDropbox)
+
+	if model.name != "ProviderType" {
+		t.Errorf("expected name 'ProviderType', got %q", model.name)
+	}
+	if model.schema == nil {
+		t.Fatal("expected schema to be set")
+	}
+	if model.schema.Type == nil || model.schema.Type.String() != "string" {
+		t.Errorf("expected string type, got %v", model.schema.Type)
+	}
+	if len(model.schema.Enum) != 3 {
+		t.Fatalf("expected 3 enum values, got %d", len(model.schema.Enum))
+	}
+	expected := []string{"google_drive", "onedrive", "dropbox"}
+	for i, v := range model.schema.Enum {
+		if v != expected[i] {
+			t.Errorf("enum[%d]: expected %q, got %v", i, expected[i], v)
+		}
+	}
+}
+
+func TestNewEnumModel_AppearsInOpenAPI(t *testing.T) {
+	engine := newTestEngine()
+
+	engine.WithModels(
+		NewEnumModel("ProviderType", ProviderGoogleDrive, ProviderOneDrive, ProviderDropbox),
+	)
+
+	spec := engine.GenerateOpenAPI(nil)
+
+	schema, exists := spec.Components.Schemas["ProviderType"]
+	if !exists {
+		t.Fatal("expected ProviderType in component schemas")
+	}
+	if schema.Type == nil || schema.Type.String() != "string" {
+		t.Errorf("expected string type, got %v", schema.Type)
+	}
+	if len(schema.Enum) != 3 {
+		t.Errorf("expected 3 enum values, got %d", len(schema.Enum))
+	}
+}
+
+func TestNewSchemaModel(t *testing.T) {
+	schema := &openapi.Schema{
+		Type: openapi.NewSchemaType("object"),
+		AdditionalProperties: &openapi.Schema{
+			Ref: "#/components/schemas/FacetCount",
+		},
+	}
+	model := NewSchemaModel("SearchFacets", schema)
+
+	if model.name != "SearchFacets" {
+		t.Errorf("expected name 'SearchFacets', got %q", model.name)
+	}
+	if model.schema != schema {
+		t.Error("expected schema to be the same pointer")
+	}
+}
+
+func TestNewSchemaModel_AppearsInOpenAPI(t *testing.T) {
+	engine := newTestEngine()
+
+	engine.WithModels(
+		NewSchemaModel("SearchFacets", &openapi.Schema{
+			Type: openapi.NewSchemaType("object"),
+			AdditionalProperties: &openapi.Schema{
+				Ref: "#/components/schemas/FacetCount",
+			},
+		}),
+	)
+
+	spec := engine.GenerateOpenAPI(nil)
+
+	schema, exists := spec.Components.Schemas["SearchFacets"]
+	if !exists {
+		t.Fatal("expected SearchFacets in component schemas")
+	}
+	if schema.Type == nil || schema.Type.String() != "object" {
+		t.Errorf("expected object type, got %v", schema.Type)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `NewEnumModel[T ~string](name, values...)` for registering string enum types as OpenAPI component schemas
- Add `NewSchemaModel(name, schema)` as an escape hatch for arbitrary schema registration (maps, custom types, etc.)
- Fix `goTypeToSchema` to resolve map value types into `additionalProperties` schemas instead of `additionalProperties: true`

Closes #25

## Test plan
- [x] `NewEnumModel` unit + OpenAPI integration tests
- [x] `NewSchemaModel` unit + OpenAPI integration tests
- [x] `goTypeToSchema` map value parsing tests (`map[string]string`, `map[string]SomeStruct`, `map[string][]int`)
- [x] All existing tests pass
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)