### PR TITLE
feat: add WithTLSConfig option for HTTPS support

### DIFF
--- a/docs/5.reference/1.api.md
+++ b/docs/5.reference/1.api.md
@@ -115,6 +115,14 @@ func (e *Engine) WithCodec(codec Codec) *Engine
 
 Sets the default codec for all handlers registered with this engine. Handlers that explicitly call `WithCodec()` will use their own codec instead.
 
+#### WithTLSConfig
+
+```go
+func (e *Engine) WithTLSConfig(config *tls.Config) *Engine
+```
+
+Sets the TLS configuration for the engine's HTTP server. When set, the server will use TLS (HTTPS) instead of plain HTTP. Certificates should be provided via the `tls.Config` (e.g., using `tls.Config.Certificates` or `tls.Config.GetCertificate`).
+
 #### Router
 
 ```go

--- a/docs/5.reference/3.events.md
+++ b/docs/5.reference/3.events.md
@@ -54,6 +54,7 @@ Emitted when server starts listening.
 | Field | Type | Description |
 |-------|------|-------------|
 | `AddressKey` | string | Address being listened on |
+| `TLSEnabledKey` | bool | Whether TLS is enabled |
 
 ### EngineShutdownStarted
 

--- a/engine.go
+++ b/engine.go
@@ -2,6 +2,7 @@ package rocco
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -37,6 +38,7 @@ type Engine struct {
 	cachedOpenAPISpec   []byte      // Cached JSON-encoded OpenAPI spec
 	openAPIOnce         sync.Once   // Ensures OpenAPI spec is generated only once
 	codec               Codec       // Default codec for handlers (nil = use handler default)
+	tlsConfig           *tls.Config // TLS configuration (nil = plain HTTP)
 }
 
 // NewEngine creates a new Engine.
@@ -85,6 +87,13 @@ func (e *Engine) WithAuthenticator(extractor func(context.Context, *http.Request
 // Handlers that explicitly call WithCodec() will use their own codec instead.
 func (e *Engine) WithCodec(codec Codec) *Engine {
 	e.codec = codec
+	return e
+}
+
+// WithTLSConfig sets the TLS configuration for the engine's HTTP server.
+// When set, the server will use TLS (HTTPS) instead of plain HTTP.
+func (e *Engine) WithTLSConfig(config *tls.Config) *Engine {
+	e.tlsConfig = config
 	return e
 }
 
@@ -506,14 +515,22 @@ func (e *Engine) Start(host string, port int) error {
 		ReadTimeout:  e.config.ReadTimeout,
 		WriteTimeout: e.config.WriteTimeout,
 		IdleTimeout:  e.config.IdleTimeout,
+		TLSConfig:    e.tlsConfig,
 	}
 
 	// Emit engine starting event
 	capitan.Info(e.ctx, EngineStarting,
 		AddressKey.Field(addr),
+		TLSEnabledKey.Field(e.tlsConfig != nil),
 	)
 
-	err := e.server.ListenAndServe()
+	var err error
+	if e.tlsConfig != nil {
+		// Certificates are provided via TLSConfig, so cert/key file args are empty.
+		err = e.server.ListenAndServeTLS("", "")
+	} else {
+		err = e.server.ListenAndServe()
+	}
 	if err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("server error: %w", err)
 	}

--- a/engine_test.go
+++ b/engine_test.go
@@ -2,14 +2,23 @@ package rocco
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/zoobz-io/capitan"
 	"github.com/zoobz-io/openapi"
 )
 
@@ -1038,6 +1047,175 @@ func TestEngine_WithCodec_HandlerOverride(t *testing.T) {
 	spec := handler.Spec()
 	if spec.ContentType != "application/yaml" {
 		t.Errorf("expected content type 'application/yaml', got %q", spec.ContentType)
+	}
+}
+
+func TestEngine_WithTLSConfig(t *testing.T) {
+	tlsCfg := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+	}
+	engine := newTestEngine().WithTLSConfig(tlsCfg)
+
+	if engine.tlsConfig == nil {
+		t.Fatal("expected tlsConfig to be set")
+	}
+	if engine.tlsConfig.MinVersion != tls.VersionTLS13 {
+		t.Errorf("expected MinVersion TLS 1.3, got %d", engine.tlsConfig.MinVersion)
+	}
+}
+
+func TestEngine_WithTLSConfig_Nil(t *testing.T) {
+	engine := newTestEngine().WithTLSConfig(nil)
+
+	if engine.tlsConfig != nil {
+		t.Error("expected tlsConfig to be nil")
+	}
+}
+
+func TestEngine_WithTLSConfig_Chaining(t *testing.T) {
+	tlsCfg := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+	}
+	engine := newTestEngine().
+		WithTLSConfig(tlsCfg).
+		WithMiddleware(func(next http.Handler) http.Handler { return next })
+
+	if engine.tlsConfig == nil {
+		t.Fatal("expected tlsConfig to be set after chaining")
+	}
+	if len(engine.globalMiddleware) != 1 {
+		t.Errorf("expected 1 middleware, got %d", len(engine.globalMiddleware))
+	}
+}
+
+func TestEngine_Start_WithTLS(t *testing.T) {
+	setupSyncMode(t)
+
+	tlsCfg := newTestTLSConfig(t)
+	engine := NewEngine().WithTLSConfig(tlsCfg)
+
+	handler := NewHandler[NoBody, testOutput](
+		"tls-test",
+		"GET",
+		"/tls",
+		func(_ *Request[NoBody]) (testOutput, error) {
+			return testOutput{Message: "secure"}, nil
+		},
+	)
+	engine.WithHandlers(handler)
+
+	started := make(chan struct{}, 1)
+	listener := capitan.Hook(EngineStarting, func(_ context.Context, _ *capitan.Event) {
+		started <- struct{}{}
+	})
+	defer listener.Close()
+
+	// Start server in background
+	go func() {
+		_ = engine.Start(HostLocal, 0)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("engine did not start")
+	}
+
+	// Verify the engine's tlsConfig was set on the server
+	if engine.server.TLSConfig != tlsCfg {
+		t.Error("expected server TLSConfig to match engine tlsConfig")
+	}
+
+	// Shutdown
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	if err := engine.Shutdown(ctx); err != nil {
+		t.Errorf("unexpected shutdown error: %v", err)
+	}
+}
+
+func TestEngine_Start_WithoutTLS(t *testing.T) {
+	setupSyncMode(t)
+
+	engine := NewEngine()
+
+	handler := NewHandler[NoBody, testOutput](
+		"plain-test",
+		"GET",
+		"/plain",
+		func(_ *Request[NoBody]) (testOutput, error) {
+			return testOutput{Message: "plain"}, nil
+		},
+	)
+	engine.WithHandlers(handler)
+
+	started := make(chan struct{}, 1)
+	listener := capitan.Hook(EngineStarting, func(_ context.Context, _ *capitan.Event) {
+		started <- struct{}{}
+	})
+	defer listener.Close()
+
+	// Start server in background
+	go func() {
+		_ = engine.Start(HostLocal, 0)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("engine did not start")
+	}
+
+	// Verify the engine itself has no TLS config
+	if engine.tlsConfig != nil {
+		t.Error("expected engine tlsConfig to be nil")
+	}
+
+	// Shutdown
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	if err := engine.Shutdown(ctx); err != nil {
+		t.Errorf("unexpected shutdown error: %v", err)
+	}
+}
+
+// newTestTLSConfig generates a self-signed TLS config for testing.
+func newTestTLSConfig(t *testing.T) *tls.Config {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{Organization: []string{"test"}},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		DNSNames:     []string{"localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("failed to load keypair: %v", err)
+	}
+
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{cert},
 	}
 }
 

--- a/events.go
+++ b/events.go
@@ -161,7 +161,8 @@ var (
 // Event field keys (primitive types only).
 var (
 	// Engine fields.
-	AddressKey = capitan.NewStringKey("address")
+	AddressKey    = capitan.NewStringKey("address")
+	TLSEnabledKey = capitan.NewBoolKey("tls_enabled")
 
 	// Request/Response fields.
 	MethodKey      = capitan.NewStringKey("method")

--- a/events_test.go
+++ b/events_test.go
@@ -484,6 +484,72 @@ func TestEvents_RequestValidationOutputFailed(t *testing.T) {
 	}
 }
 
+func TestEvents_EngineStarting_TLSEnabled(t *testing.T) {
+	setupSyncMode(t)
+
+	var tlsEnabled bool
+	received := make(chan struct{}, 1)
+
+	listener := capitan.Hook(EngineStarting, func(_ context.Context, e *capitan.Event) {
+		tlsEnabled, _ = TLSEnabledKey.From(e)
+		received <- struct{}{}
+	})
+	defer listener.Close()
+
+	engine := NewEngine().WithTLSConfig(newTestTLSConfig(t))
+
+	go func() {
+		_ = engine.Start(HostLocal, 0)
+	}()
+
+	select {
+	case <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("EngineStarting not emitted")
+	}
+
+	if !tlsEnabled {
+		t.Error("expected tls_enabled to be true")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	_ = engine.Shutdown(ctx)
+}
+
+func TestEvents_EngineStarting_TLSDisabled(t *testing.T) {
+	setupSyncMode(t)
+
+	var tlsEnabled bool
+	received := make(chan struct{}, 1)
+
+	listener := capitan.Hook(EngineStarting, func(_ context.Context, e *capitan.Event) {
+		tlsEnabled, _ = TLSEnabledKey.From(e)
+		received <- struct{}{}
+	})
+	defer listener.Close()
+
+	engine := NewEngine()
+
+	go func() {
+		_ = engine.Start(HostLocal, 0)
+	}()
+
+	select {
+	case <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("EngineStarting not emitted")
+	}
+
+	if tlsEnabled {
+		t.Error("expected tls_enabled to be false")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	_ = engine.Shutdown(ctx)
+}
+
 func TestEvents_EngineShutdown(t *testing.T) {
 	setupSyncMode(t)
 


### PR DESCRIPTION
## Summary
- Adds `WithTLSConfig(*tls.Config)` option to `Engine` enabling HTTPS via `ListenAndServeTLS`
- Emits `TLSEnabledKey` field on the `EngineStarting` event for observability
- Updates API and events reference docs

## Test plan
- [x] All existing tests pass
- [ ] Manual verification with a self-signed cert

🤖 Generated with [Claude Code](https://claude.com/claude-code)