### PR TITLE
fix: strip wildcard suffix when extracting path params

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -342,6 +342,30 @@ func TestHandler_ExtractParams_PathParams(t *testing.T) {
 	}
 }
 
+func TestHandler_ExtractParams_WildcardPathParam(t *testing.T) {
+	handler := NewHandler[NoBody, testOutput](
+		"test",
+		"GET",
+		"/content/{path...}",
+		func(_ *Request[NoBody]) (testOutput, error) {
+			return testOutput{}, nil
+		},
+	).WithPathParams("path...")
+
+	req := httptest.NewRequest("GET", "/content/src/lib/main.go", nil)
+	req.SetPathValue("path", "src/lib/main.go")
+
+	spec := handler.Spec()
+	params, err := extractParams(context.Background(), req, spec.PathParams, spec.QueryParams)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.Path["path..."] != "src/lib/main.go" {
+		t.Errorf("expected path param 'path...' = 'src/lib/main.go', got %q", params.Path["path..."])
+	}
+}
+
 func TestHandler_ExtractParams_MissingPathParam(t *testing.T) {
 	handler := NewHandler[NoBody, testOutput](
 		"test",

--- a/request.go
+++ b/request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // noBodyTypeName is the sentinel type name for handlers without a request body.
@@ -43,7 +44,8 @@ func extractParams(_ context.Context, r *http.Request, pathParams, queryParams [
 
 	// Extract path params using Go 1.22+ PathValue.
 	for _, param := range pathParams {
-		if val := r.PathValue(param); val != "" {
+		lookupKey := strings.TrimSuffix(param, "...")
+		if val := r.PathValue(lookupKey); val != "" {
 			params.Path[param] = val
 		} else {
 			return nil, fmt.Errorf("path parameter %q", param)


### PR DESCRIPTION
## Summary
- Strip `...` suffix from wildcard path param names before calling `r.PathValue()`, fixing 422 errors on wildcard routes like `{path...}`
- Store the extracted value under the original key (e.g. `"path..."`) to preserve the existing API
- Add test for wildcard path param extraction

Closes #31

## Test plan
- [x] New test `TestHandler_ExtractParams_WildcardPathParam` passes
- [x] All existing tests pass
- [ ] Manual verification with a wildcard route (e.g. `/content/{path...}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)